### PR TITLE
Bug fix

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -28,7 +28,7 @@ ul {
     list-style: none;
 }
 
-button, input, textarea, .button {
+button, input, textarea, .button, select {
     height: 2.25rem;
     border-radius: 1.25rem;
     border: 1px solid $secondary2;

--- a/src/components/AddInventoryItem/AddInventoryItem.scss
+++ b/src/components/AddInventoryItem/AddInventoryItem.scss
@@ -49,8 +49,7 @@
         margin: 1rem 0;
     }
     @include desktop {
-        padding: 0 2.5rem;
-        width: 80vw;
+        width: 100%;
     }
 
     &-status{
@@ -97,11 +96,7 @@
 
         @include tablet {
             @include typography-style (0.875rem, 1.375rem, 600);
-            width: 15vw;
-        }
-
-        @include desktop{
-            width: 10vw;
+            width: auto;
         }
 
         &:hover {
@@ -117,11 +112,7 @@
         @include typography-style (0.8125rem, 1.25rem, 600);
         @include tablet {
             @include typography-style (0.875rem, 1.375rem, 600);
-            width: 15vw;
-        }
-
-        @include desktop{
-            width: 8vw;
+            width: auto;
         }
 
         &:hover {
@@ -142,8 +133,8 @@
             }
 
             @include desktop{
-                width: 35vw;
-                padding-left:0;
+                width: 50%;
+                padding: 0 2.5rem;
             }
     }
 
@@ -164,8 +155,6 @@
 
     &-heading {
         @include pad-top-bottom (0, 1rem);
-        font-size: 1.25rem;
-        line-height: 1.75rem;
         @include tablet {
             padding: 0 0 1.5rem 0;
         }
@@ -214,11 +203,11 @@
 
         @include tablet {
             border: none;
-            width: 40vw;
+            width: 50%;
         }
 
         @include desktop {
-            padding: 1rem 3.7rem;
+            padding: 0 2.5rem;
         }
     }
 

--- a/src/components/AddWarehouse/AddWarehouse.scss
+++ b/src/components/AddWarehouse/AddWarehouse.scss
@@ -44,7 +44,7 @@
 }
 
 .details__form {
-    padding: 1rem 1rem 0.5rem 1rem;
+    padding: 1rem;
     border-bottom: 1px solid $secondary2;
     @include tablet {
         @include padding-tablet;
@@ -109,7 +109,7 @@
     }
 
     &-heading {
-        @include pad-top-bottom (1rem, 1rem);
+        @include pad-top-bottom (0, 1rem);
         @include tablet {
             padding: 0 0 1.5rem 0;
         }

--- a/src/components/AddWarehouse/AddWarehouse.scss
+++ b/src/components/AddWarehouse/AddWarehouse.scss
@@ -116,7 +116,7 @@
     }
 
     &-input {
-        margin-bottom: 0.5rem;
+        margin-bottom: 1rem;
 
         &::placeholder {
             color: $secondary1;

--- a/src/components/EditInventoryItem/EditInventoryItem.js
+++ b/src/components/EditInventoryItem/EditInventoryItem.js
@@ -150,7 +150,7 @@ function EditInventoryItem() {
                                 <button className='details__edit-form-cancel' onClick={() => navigate('/inventories')}>Cancel</button>
                             </div>
                             <div className="details__edit-form-btns-a">
-                                <button className='details__edit-form-edit' type="submit">Edit Item</button>
+                                <button className='details__edit-form-edit' type="submit">Save</button>
                             </div>
                         </div>
                     </form>

--- a/src/components/EditInventoryItem/EditInventoryItem.scss
+++ b/src/components/EditInventoryItem/EditInventoryItem.scss
@@ -27,15 +27,10 @@
         @include tablet {
             @include padding-tablet;
         }
-        @include desktop {
-            padding-left: 2.5rem;
-            padding-left: 2.5rem;
-        }
     }
     
     &-heading {
-        flex-wrap: nowrap;
-        
+        flex-wrap: nowrap;   
     }
 }
 
@@ -44,13 +39,11 @@
         display:flex;
         flex-direction: row;
         justify-content: space-between;
-        width: 90vw;
         padding: 1rem 0;
         margin: 1rem 0;
     }
     @include desktop {
-        padding: 0 2.5rem;
-        width: 80vw;
+        padding: 0;
     }
 
     &-status{
@@ -97,11 +90,7 @@
 
         @include tablet {
             @include typography-style (0.875rem, 1.375rem, 600);
-            width: 15vw;
-        }
-
-        @include desktop{
-            width: 10vw;
+            width: auto;
         }
 
         &:hover {
@@ -117,11 +106,7 @@
         @include typography-style (0.8125rem, 1.25rem, 600);
         @include tablet {
             @include typography-style (0.875rem, 1.375rem, 600);
-            width: 15vw;
-        }
-
-        @include desktop{
-            width: 8vw;
+            width: auto;
         }
 
         &:hover {
@@ -135,13 +120,12 @@
             padding: 1rem 1rem 1rem 1rem;
 
             @include tablet{
-                width: 45vw;
+                width: 50%;
                 border-right: 1px solid $secondary2;
-                padding-right: 50px;
             }
 
             @include desktop{
-                width: 35vw;
+                width: 50%;
             }
     }
 
@@ -163,7 +147,7 @@
     &-heading {
         @include pad-top-bottom (0, 1rem);
         @include tablet {
-            padding: 0 0 1.5rem 0;
+            padding: 0 0 1rem 0;
         }
     }
 
@@ -246,16 +230,19 @@
         @include display (column, space-between, nowrap);
 
         @include tablet{
-            padding-left: 2rem;
+            padding: 0 2rem;
         }
 
         @include desktop{
-            padding-left: 0;
+            padding: 0 2.5rem;
         }
 
         &--bottom {
             @include mobile {
                 border-bottom: none;
+            }
+            @include tablet {
+                border-right: none;
             }
         }
     }

--- a/src/components/EditInventoryItem/EditInventoryItem.scss
+++ b/src/components/EditInventoryItem/EditInventoryItem.scss
@@ -276,6 +276,9 @@
 #in, #out {
     width: 10px;
     
+    &:checked {
+        outline: none;
+    }
 }
 
 .stock-txt{

--- a/src/components/EditInventoryItem/EditInventoryItem.scss
+++ b/src/components/EditInventoryItem/EditInventoryItem.scss
@@ -162,8 +162,6 @@
 
     &-heading {
         @include pad-top-bottom (0, 1rem);
-        font-size: 1.25rem;
-        line-height: 1.75rem;
         @include tablet {
             padding: 0 0 1.5rem 0;
         }
@@ -228,6 +226,7 @@
         display:flex;
         flex-direction: column;
         color: $primary1;
+        gap: 0.25rem;
 
         &--in-stock{
             @include typography-style (0.8125rem, 1.25rem, 600);
@@ -241,7 +240,9 @@
 
 
     &-item-details {
-        
+        @include mobile {
+            border-bottom: 1px solid $secondary2;
+        }
         @include display (column, space-between, nowrap);
 
         @include tablet{
@@ -250,6 +251,12 @@
 
         @include desktop{
             padding-left: 0;
+        }
+
+        &--bottom {
+            @include mobile {
+                border-bottom: none;
+            }
         }
     }
 

--- a/src/components/EditWarehouse/EditWarehouse.js
+++ b/src/components/EditWarehouse/EditWarehouse.js
@@ -87,29 +87,20 @@ function EditWarehouse({ id }) {
                                <h2 className="details__edit-form-heading">Warehouse Details</h2>
                                     <div className="details__edit-form-label">
                                         <label className="details__edit-form-label" htmlFor='warehouse_id'>Warehouse Name
-                                            <select className='details__edit-form-input--dropdown' id='warehouse_id' defaultValue={id}>
-                                                <option value="" disabled>Please select</option>
-                                                <option value="1">Manhattan</option>
-                                                <option value="2">Washington</option>
-                                                <option value="3">Jersey</option>
-                                                <option value="4">San Francisco</option>
-                                                <option value="5">Santa Monica</option>
-                                                <option value="6">Seattle</option>
-                                                <option value="7">Miami</option>
-                                            </select>
+                                            <input type="text" id='warehouse_id' defaultValue={id} placeholder="Warehouse Name"></input>
                                         </label>
                                     </div>
         
 
-                                 <label className="details__edit-form-label" htmlFor='item_name'> Street Address
+                                 <label className="details__edit-form-label" htmlFor='street_address'> Street Address
                                      <input className='details__edit-form-input' type='text' id='street_address' placeholder="Street Address" defaultValue={warehouse.address} />
                                  </label>
 
-                                 <label className="details__edit-form-label" htmlFor='item_name'> City
+                                 <label className="details__edit-form-label" htmlFor='city'> City
                                      <input className='details__edit-form-input' type='text' id='city' placeholder="City" defaultValue={warehouse.city} />
                                  </label>
 
-                             <label className="details__edit-form-label" htmlFor='item_name'> Country
+                             <label className="details__edit-form-label" htmlFor='country'> Country
                                      <input className='details__edit-form-input' type='text' id='country' placeholder="Country" defaultValue={warehouse.country} />
                                  </label>
 
@@ -117,15 +108,19 @@ function EditWarehouse({ id }) {
                              <div className="details__edit-form-item-details details__edit-form-item-details--bottom">
                                  <h2 className="details__edit-form-heading">Contact Details</h2>
 
-                                 <label className="details__edit-form-label" htmlFor='item_name'> Position
+                                 <label className="details__edit-form-label" htmlFor='contact_name'> Contact Name
+                                     <input className='details__edit-form-input' type='text' id='contact_name' placeholder="Contact Name" defaultValue={warehouse.contact_name} />
+                                 </label>
+
+                                 <label className="details__edit-form-label" htmlFor='position'> Position
                                      <input className='details__edit-form-input' type='text' id='position' placeholder="Position" defaultValue={warehouse.contact_position} />
                                  </label>
 
-                                 <label className="details__edit-form-label" htmlFor='item_name'> Phone Number
+                                 <label className="details__edit-form-label" htmlFor='phone_number'> Phone Number
                                      <input className='details__edit-form-input' type='text' id='phone_number' placeholder="Phone Number" defaultValue={warehouse.contact_phone} />
                                  </label>
 
-                                 <label className="details__edit-form-label" htmlFor='item_name'> Email
+                                 <label className="details__edit-form-label" htmlFor='email'> Email
                                      <input className='details__edit-form-input' type='text' id='email' placeholder="Email" defaultValue={warehouse.email} />
                                  </label>
                                  

--- a/src/components/EditWarehouse/EditWarehouse.js
+++ b/src/components/EditWarehouse/EditWarehouse.js
@@ -85,9 +85,8 @@ function EditWarehouse({ id }) {
                          <div className="details__edit-form">
                              <div className="details__edit-form-item-details">
                                <h2 className="details__edit-form-heading">Warehouse Details</h2>
-                                    <div>
-                                        <h3 className="details__edit-form-label">Warehouse</h3>
-                                        <label htmlFor='warehouse_id'>
+                                    <div className="details__edit-form-label">
+                                        <label className="details__edit-form-label" htmlFor='warehouse_id'>Warehouse Name
                                             <select className='details__edit-form-input--dropdown' id='warehouse_id' defaultValue={id}>
                                                 <option value="" disabled>Please select</option>
                                                 <option value="1">Manhattan</option>
@@ -115,29 +114,29 @@ function EditWarehouse({ id }) {
                                  </label>
 
                              </div>
-                             <div className="details__edit-form-item-details">
+                             <div className="details__edit-form-item-details details__edit-form-item-details--bottom">
                                  <h2 className="details__edit-form-heading">Contact Details</h2>
 
                                  <label className="details__edit-form-label" htmlFor='item_name'> Position
-                                     <input className='details__edit-form-input' type='text' id='position' placeholder="position" defaultValue={warehouse.contact_position} />
+                                     <input className='details__edit-form-input' type='text' id='position' placeholder="Position" defaultValue={warehouse.contact_position} />
                                  </label>
 
                                  <label className="details__edit-form-label" htmlFor='item_name'> Phone Number
-                                     <input className='details__edit-form-input' type='text' id='phone_number' placeholder="phone number" defaultValue={warehouse.contact_phone} />
+                                     <input className='details__edit-form-input' type='text' id='phone_number' placeholder="Phone Number" defaultValue={warehouse.contact_phone} />
                                  </label>
 
                                  <label className="details__edit-form-label" htmlFor='item_name'> Email
                                      <input className='details__edit-form-input' type='text' id='email' placeholder="Email" defaultValue={warehouse.email} />
                                  </label>
-                                 <div className='details__form-container'>
-                                     <Link to='..' className='details__form-link'><button className='details__form-cancel'>Cancel</button></Link>
-                                     <button className='details__form-add' type='submit'> Edit Warehouse </button>
-                                 </div>
+                                 
 
 
                              </div>
                          </div>
-
+                         <div className='details__form-container'>
+                                     <Link to='..' className='details__form-link'><button className='details__form-cancel'>Cancel</button></Link>
+                                     <button className='details__form-add' type='submit'>Save</button>
+                                 </div>
 
                      </form>
                  </section>

--- a/src/components/InventoryList/InventoryList.js
+++ b/src/components/InventoryList/InventoryList.js
@@ -149,7 +149,7 @@ function InventoryList() {
                                 </div>
                                 <div className="items-list__card-info-de">
                                     <img className="items-list__card-info-de-delete" alt="delete-icon" src={deleteIcon} onClick={() => toggleModal(item.id)} />
-                                    <Link to={`/inventories/${item.id}/edit`}>
+                                    <Link className="edit__button" to={`/inventories/${item.id}/edit`}>
                                         <img className="items-list__card-info-de-edit" alt="edit-icon" src={editIcon} />
                                     </Link>
                                 </div>

--- a/src/components/InventoryList/InventoryList.scss
+++ b/src/components/InventoryList/InventoryList.scss
@@ -102,8 +102,7 @@
         &__table-header{
             display:none;
             background-color: #F7F8F9;
-            padding: 0 1.5rem;
-            height: 4vh;
+            padding: 0.5rem 1.5rem;
         
 
             @include tablet{
@@ -198,6 +197,10 @@
 
         &__container{
             border-top: 1px #BDC5D5 solid ;
+            
+            &:nth-child(2) {
+                border-top: none;
+            }
         }
 
         &__card{

--- a/src/components/InventoryList/InventoryList.scss
+++ b/src/components/InventoryList/InventoryList.scss
@@ -22,18 +22,17 @@
     }
 
     &-header {
-    
     padding: 1rem;
 
     @include tablet{
         display:flex;
         flex-direction: row;
         justify-content: space-between;
-        padding-bottom: 1.875rem;
+        padding: 1.5rem 2rem;
     }
 
     @include desktop{
-        padding: 1.875rem 2rem;
+        padding: 1.5rem 2.5rem;
     }
 
         &__title {
@@ -52,6 +51,7 @@
                 align-items: center;
                 width: 53vw;
                 justify-content: flex-end;
+                gap: 1rem;
             }
 
             @include desktop{
@@ -109,10 +109,17 @@
                 display:flex;
                 flex-direction: row;
                 align-items: center;
+                padding: 0.5rem 2rem;
             }
 
             @include desktop{
-                padding: 0 2rem;
+                padding: 0.5rem 2.5rem;
+            }
+
+            &--actions {
+                @include desktop {
+                    margin-left: auto;
+                }
             }
 
             &-ic{
@@ -197,9 +204,11 @@
 
         &__container{
             border-top: 1px #BDC5D5 solid ;
-            
+
             &:nth-child(2) {
+                @include tablet {
                 border-top: none;
+                }
             }
         }
 
@@ -211,11 +220,11 @@
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: center;
-                padding: 1rem 1.5rem;
+                padding: 1rem 2rem;
             }
 
             @include desktop{
-                padding: 1rem 2rem;
+                padding: 1.5rem 2.5rem;
             }
 
             &-info{
@@ -260,6 +269,7 @@
 
                         &-label {
                             font-weight:550;
+                            color: #5C667E;
                             @include tablet{
                                 display:none;
                             }
@@ -291,6 +301,7 @@
 
                         &-label {
                             font-weight:550;
+                            color: #5C667E;
                             @include tablet{
                                 display:none;
                             }
@@ -335,6 +346,7 @@
 
                         &-label {
                             font-weight:550;
+                            color: #5C667E;
                             @include tablet{
                                 display:none;
                             }
@@ -375,14 +387,13 @@
                             color: rgb(21,132,99);
                             font-weight:550;
                             text-align: center;
-                            font-size: 11px;
                         }
 
                         &-txt--out-of-stock{
                             color: rgb(201,69,21);
                             font-weight:550;
                             text-align: center;
-                            font-size: 11px;
+                            white-space: nowrap;
                         }
                     }
 
@@ -398,6 +409,7 @@
 
                         &-label {
                             font-weight:550;
+                            color: #5C667E;
                             @include tablet{
                                 display:none;
                             }
@@ -423,6 +435,7 @@
 
                         &-label {
                             font-weight:550;
+                            color: #5C667E;
                             @include tablet{
                                 display:none;
                             }
@@ -445,7 +458,11 @@
 
                 @include tablet{
                     width: 10vw;
-                    justify-content: center;
+                    justify-content: flex-end;
+                }
+
+                @include desktop {
+                    gap: 0.5rem;
                 }
 
                 &-delete{
@@ -459,6 +476,10 @@
 
 
     }
+}
+
+.edit__button {
+    max-height: 1.5rem;
 }
 
 .items-list__container:hover{

--- a/src/components/WarehouseDetails/WarehouseDetails.scss
+++ b/src/components/WarehouseDetails/WarehouseDetails.scss
@@ -108,6 +108,10 @@
             &:nth-of-type(2){
                 padding-left: 2.5rem;
                 width: 30.5%;
+
+                @include desktop {
+                    width: 29.5%;
+                }
             }
         }
 

--- a/src/components/WarehouseList/WarehouseList.js
+++ b/src/components/WarehouseList/WarehouseList.js
@@ -148,7 +148,7 @@ function WarehouseList() {
                                 </div>
                             </div>
                             {modal === warehouse.id && 
-                            <DeleteWarehouse toggleModal={toggleModal} warehouse={warehouse} refreshWarehouses={refreshWarehouses} />}
+                            <DeleteWarehouse toggleModal={closeModal} warehouse={warehouse} refreshWarehouses={refreshWarehouses} />}
                         </article>
                 ))
                     }

--- a/src/components/WarehouseList/WarehouseList.scss
+++ b/src/components/WarehouseList/WarehouseList.scss
@@ -33,7 +33,7 @@
     }
 
     @include desktop{
-        padding: 1.875rem 2rem;
+        padding: 1.5rem 2.5rem;
     }
 
         &__title {
@@ -111,8 +111,7 @@
             }
 
             @include desktop{
-                padding: 0 2rem;
-                height: 4vh;
+                padding: 0.5rem 2.5rem;
             }
 
 
@@ -182,7 +181,9 @@
             border-top: 1px #BDC5D5 solid;
 
             &:nth-child(2) {
-                border-top: none;
+                @include tablet {
+                    border-top: none;
+                }
             }
         }
 
@@ -198,7 +199,7 @@
             }
 
             @include desktop{
-                padding: 1rem 2rem;
+                padding: 1rem 2.5rem;
             }
 
 
@@ -227,11 +228,13 @@
                     }
 
                     @include desktop{
-                        width: 36vw;
+                        width: 35vw;
                     }
 
                     &--warehouse{
-                        padding-bottom: .625rem;
+                        @include mobile {
+                          padding-bottom: .625rem;  
+                        }
 
                         &-label{
                             font-weight: 550;
@@ -249,10 +252,6 @@
                             &-name{
                                 color: #2E66E5;
                                 font-weight: 550;
-
-                                @include tablet{
-                                    @include typography-style (0.875rem, 1.375rem, 550)
-                                }
                             }
                         }
                     }
@@ -305,7 +304,8 @@
                     }
 
                     @include desktop{
-                        width: 35vw;
+                        width: 33vw;
+                        justify-content: flex-start;
                     }
 
                     &--contact-name{
@@ -339,6 +339,9 @@
                         @include tablet{
                             width: 20vw;
                         }
+                        @include desktop {
+                            width: auto;
+                        }
 
                         &-label{
 
@@ -362,13 +365,20 @@
                     width: 10vw;
                     justify-content: center;
                 }
+                @include desktop {
+                    gap: 1rem;
+                }
 
                 &-delete{
+                    max-height: 1.5rem;
                     cursor: pointer;
                     @include tablet{
                         padding-right: .625rem;
                     }
-                }
+                    @include desktop {
+                        padding-right: 0;
+                    }
+                }               
             }
         }
 

--- a/src/components/WarehouseList/WarehouseList.scss
+++ b/src/components/WarehouseList/WarehouseList.scss
@@ -180,7 +180,7 @@
 
         &__container{
             border-top: 1px #BDC5D5 solid;
-            
+
             &:nth-child(2) {
                 border-top: none;
             }
@@ -348,17 +348,6 @@
                             @include tablet{
                                 display:none;
                             }
-                        }
-
-                        &-ph--phone{
-                            font-size: 11px;
-                            @include desktop{@include typography-style (0.875rem, 1.375rem, 400)}
-                            
-                        }
-
-                        &-ph--email{
-                            font-size:11px;
-                            @include desktop{@include typography-style (0.875rem, 1.375rem, 400)}
                         }
                     
                     }

--- a/src/components/WarehouseList/WarehouseList.scss
+++ b/src/components/WarehouseList/WarehouseList.scss
@@ -29,7 +29,7 @@
         display:flex;
         flex-direction: row;
         justify-content: space-between;
-        padding-bottom: 1.875rem;
+        padding: 1.5rem 2rem;
     }
 
     @include desktop{
@@ -49,6 +49,7 @@
             @include tablet{
                 display: flex;
                 flex-direction: row;
+                justify-content: flex-end;
                 align-items: center;
                 width: 53vw;
             }
@@ -84,7 +85,7 @@
             padding-top: 1rem;
 
             @include tablet{
-                padding: 0 1.25rem;
+                padding: 0 0 0 1.25rem;
             }
 
             &__btn{
@@ -101,10 +102,8 @@
         &__table-header{
             display:none;
             background-color: #F7F8F9;
-            padding: 0 1.5rem;
-            height: 5vw;
+            padding: 0.5rem 2rem;
         
-
             @include tablet{
                 display:flex;
                 flex-direction: row;
@@ -115,6 +114,7 @@
                 padding: 0 2rem;
                 height: 4vh;
             }
+
 
             &-ic{
                 width: 38.4vw;
@@ -179,7 +179,11 @@
         }
 
         &__container{
-            border-top: 1px #BDC5D5 solid ;
+            border-top: 1px #BDC5D5 solid;
+            
+            &:nth-child(2) {
+                border-top: none;
+            }
         }
 
         &__card{
@@ -190,12 +194,13 @@
                 flex-direction: row;
                 justify-content: space-between;
                 align-items: center;
-                padding: 1rem 1.5rem;
+                padding: 1rem 2rem;
             }
 
             @include desktop{
                 padding: 1rem 2rem;
             }
+
 
             &-info{
             display:flex;


### PR DESCRIPTION
Global
Update border color for drop down selectors (Edit Warehouse & Edit Inventory Item)
Remove square border for radio buttons on click in "Edit Inventory Item" and "Add New Inventory Item"

Delete Warehouse Modal
Document.window scroll in Warehouse List needs to be adjusted after delete modal is canceled
Nice to fix: move modal content box aligned with the end of the global header

Delete Inventory Item
Nice to fix: move modal content box aligned with the end of the global header

Add Warehouse
Mobile: Add divider between Warehouse Details and Contact Details
Mobile: Add New Warehouse middle divider padding could be more for Warehouse Details (Country and Email)
Mobile (Nice to fix): increase padding between form fields
Tablet/Desktop: Less padding-top on H2s

Warehouse List
Tablet/Desktop: Add new warehouse button should be at the end (padding: 0 0 0 1.25rem)
Tablet/Desktop: More padding-top for the header section
Remove divider line under the tag subheaders (first card top-border)
Tablet/Desktop: Contact Info font-size needs to be bigger

Inventory List
Inventory tags need to change color to a grey like the mockup (maybe check the font weight)
Tablet/Desktop: Inventory buttons need to have a gap between search and button
Tablet/Desktop: Increase padding-left and -right to (4rem for tablet, check for Desktop) for the header and list items
Tablet/Desktop: Increase padding-top for header and subheader section (update height: vh to padding)
Desktop (Nice to fix): Align "Actions" subheader & icons with "Add New Item" button

Edit Inventory item
Mobile: Increase padding-bottom for "Category" form field from the divider
Change "Edit Item" text in button to "Save"
Remove font-size and line-height for h2
Tablet/Desktop: Update button width to fit-content

Warehouse Inventory Item List
Desktop: Align "Contact Information" with "Quantity" column

Add New Inventory Item
Update border color on select drop down input
Tablet/Desktop: Less padding-top on H2s
Tablet/Desktop: Update button width to fit-content (Cancel button)
Tablet/Desktop (Nice to fix): add more padding between form fields
Desktop: Update Outer and inner padding of sections (left and right) to be 2.5rem (.details__add-form-stock needs to be 50% width)

Edit Warehouse
Button background on mobile needs to be full width (take up the whole card)
Button background needs to take up the whole bottom section in tablet/desktop
Remove font-size and line-height for h2
Update padding between form fields and labels
Capitalize placeholder text
Update "Edit Warehouse" text in button to "Save"
Tablet/Desktop: Nice to fix: remove padding-top from h2
Desktop: Adjust padding for edit warehouse buttons